### PR TITLE
[Fix]: If hdf attr is an array of string, convert to a string

### DIFF
--- a/crikit/io/hdf5.py
+++ b/crikit/io/hdf5.py
@@ -138,9 +138,16 @@ def hdf_attr_to_dict(attr):
     # String in HDF are treated as numpy bytes_ literals
     # We want out instance in memeory to have Python Strings
     # This does a simple conversion
+    # Also will check to see if a string is burried in an array
     for k in output_dict:
         if isinstance(output_dict[k], _np.bytes_):
             output_dict[k] = output_dict[k].decode('UTF-8')
+        elif isinstance(output_dict[k], _np.ndarray):
+            if output_dict[k].dtype.kind == 'S':  # String array
+                # This is a cute way of taking an array of charcters and merging
+                # them into a string. If just a single-element array,
+                # will also return a string
+                output_dict[k] = ''.join(output_dict[k].astype(_np.str))
     return output_dict
 
 def hdf_import_data(pth, filename, dset_list, output_cls_instance=None):

--- a/crikit/io/meta_process.py
+++ b/crikit/io/meta_process.py
@@ -33,6 +33,7 @@ def rosetta_query(key, rosetta, output_cls_instance):
                     if count == '!':
                         temp_key = key
                         temp_val = rosetta[key][num+1]
+                        print('Using default meta_configs value for: {}'.format(key))
                         break
                     else:
                         temp_key = count
@@ -78,7 +79,7 @@ def meta_process(rosetta, output_cls_instance):
         calib_dict['units'] = rosetta_query('ColorUnits',rosetta, output_cls_instance)[0]
 
         output_cls_instance.freq.calib = calib_dict
-        print('Calibration meta data found')
+        # print('Calibration meta data found')
 
         use_wn = rosetta_query('ColorWnMode',rosetta, output_cls_instance)[0]
         print('Use wavenumber: {}'.format(use_wn))


### PR DESCRIPTION
This mainly affects attributes that were added as strings via HDFView -- it makes the attribute an array, which is read-in by h5py as a numpy array of type S*.

This added a dtype.kind == 'S' statement and uses some tricks to convert the array into a string when imported as the meta data dictionary.

Also, added a print statement in meta_process to notify if any default meta_config values are loaded.