### PR TITLE
Py3s: Make crikit2 compatible with Python 3.4, 3.5, 3.6

### DIFF
--- a/crikit/CRIkitUI.py
+++ b/crikit/CRIkitUI.py
@@ -222,7 +222,10 @@ class CRIkitUI_process(_QMainWindow):
         # Split from previous for-loop for compactness of code
         for count, rgb_img in enumerate(self.img_RGB_list):
             color_str = rgb_img.colormode.ui.comboBoxFGColor.itemText(count)
-            rgb_img.data.colormap = _mpl.colors.to_rgb(_mpl.colors.cnames[color_str])
+
+            # Note: colors.to_rgb exists in MPL 2*, but is under colorConverter
+            # in MPL < 2.
+            rgb_img.data.colormap = _mpl.colors.colorConverter.to_rgb(_mpl.colors.cnames[color_str])
             rgb_img.colormode.ui.comboBoxFGColor.setCurrentIndex(count)
 
             rgb_img.popimage.ui.pushButtonSpectrum.setEnabled(False)
@@ -812,7 +815,7 @@ class CRIkitUI_process(_QMainWindow):
             rgb_img.data.set_y(self.hsi.y, ylabel)
             
             color_str = rgb_img.colormode.ui.comboBoxFGColor.itemText(num)
-            rgb_img.data.colormap = _mpl.colors.to_rgb(_mpl.colors.cnames[color_str])
+            rgb_img.data.colormap = _mpl.colors.colorConverter.to_rgb(_mpl.colors.cnames[color_str])
             rgb_img.colormode.ui.comboBoxFGColor.setCurrentIndex(num)
 
             # Cute way of setting the colormap to last setting and replotting

--- a/crikit/data/hsi.py
+++ b/crikit/data/hsi.py
@@ -24,16 +24,17 @@ class Hsi(_Spectrum):
     data : 3D ndarray [y_pix, x_pix, f_pix]
         HSI image
 
-    _data_idx_freq : 3D ndarray [y_pix, x_pix, f_pix]
-        EXPERIMENTAL: Retrieve data via indexing over frequency space
+    # DISABLED CURRENTLY
+    # _data_idx_freq : 3D ndarray [y_pix, x_pix, f_pix]
+    #     EXPERIMENTAL: Retrieve data via indexing over frequency space
 
-    _data_imag_over_real_idx_freq : 3D ndarray [y_pix, x_pix, f_pix]
-        EXPERIMENTAL: Retrieve data (imag priority) via indexing over frequency
-        space
+    # _data_imag_over_real_idx_freq : 3D ndarray [y_pix, x_pix, f_pix]
+    #     EXPERIMENTAL: Retrieve data (imag priority) via indexing over frequency
+    #     space
 
-    _data_real_over_imag_idx_freq : 3D ndarray [y_pix, x_pix, f_pix]
-        EXPERIMENTAL: Retrieve data (real priority) via indexing over frequency
-        space
+    # _data_real_over_imag_idx_freq : 3D ndarray [y_pix, x_pix, f_pix]
+    #     EXPERIMENTAL: Retrieve data (real priority) via indexing over frequency
+    #     space
 
     mask : 3D ndarray (int) [y_pix, x_pix, f_pix]
         0,1 mask with 1 is a usable pixel and 0 is not

--- a/crikit/data/hsi.py
+++ b/crikit/data/hsi.py
@@ -24,18 +24,6 @@ class Hsi(_Spectrum):
     data : 3D ndarray [y_pix, x_pix, f_pix]
         HSI image
 
-    # DISABLED CURRENTLY
-    # _data_idx_freq : 3D ndarray [y_pix, x_pix, f_pix]
-    #     EXPERIMENTAL: Retrieve data via indexing over frequency space
-
-    # _data_imag_over_real_idx_freq : 3D ndarray [y_pix, x_pix, f_pix]
-    #     EXPERIMENTAL: Retrieve data (imag priority) via indexing over frequency
-    #     space
-
-    # _data_real_over_imag_idx_freq : 3D ndarray [y_pix, x_pix, f_pix]
-    #     EXPERIMENTAL: Retrieve data (real priority) via indexing over frequency
-    #     space
-
     mask : 3D ndarray (int) [y_pix, x_pix, f_pix]
         0,1 mask with 1 is a usable pixel and 0 is not
 

--- a/crikit/data/spectra.py
+++ b/crikit/data/spectra.py
@@ -24,16 +24,17 @@ class Spectra(_Spectrum):
         CONVERTED to [n_pix, f_pix] shape, assuming that shape[-1] is the f_pix \
         long.
 
-    _data_idx_freq : 2D ndarray [n_pix, f_pix]
-        EXPERIMENTAL: Retrieve data via indexing over frequency space
+    # DISABLED CURRENTLY
+    # _data_idx_freq : 2D ndarray [n_pix, f_pix]
+    #     EXPERIMENTAL: Retrieve data via indexing over frequency space
         
-    _data_imag_over_real_idx_freq : 2D ndarray [n_pix, f_pix]
-        EXPERIMENTAL: Retrieve data (imag priority) via indexing over frequency 
-        space
+    # _data_imag_over_real_idx_freq : 2D ndarray [n_pix, f_pix]
+    #     EXPERIMENTAL: Retrieve data (imag priority) via indexing over frequency 
+    #     space
         
-    _data_real_over_imag_idx_freq : 2D ndarray [n_pix, f_pix]
-        EXPERIMENTAL: Retrieve data (real priority) via indexing over frequency 
-        space
+    # _data_real_over_imag_idx_freq : 2D ndarray [n_pix, f_pix]
+    #     EXPERIMENTAL: Retrieve data (real priority) via indexing over frequency 
+    #     space
 
     freq : crikit.data.frequency.Frequency instance
         Frequency [wavelength, wavenumber] object (i.e., the independent \

--- a/crikit/data/spectra.py
+++ b/crikit/data/spectra.py
@@ -24,18 +24,6 @@ class Spectra(_Spectrum):
         CONVERTED to [n_pix, f_pix] shape, assuming that shape[-1] is the f_pix \
         long.
 
-    # DISABLED CURRENTLY
-    # _data_idx_freq : 2D ndarray [n_pix, f_pix]
-    #     EXPERIMENTAL: Retrieve data via indexing over frequency space
-        
-    # _data_imag_over_real_idx_freq : 2D ndarray [n_pix, f_pix]
-    #     EXPERIMENTAL: Retrieve data (imag priority) via indexing over frequency 
-    #     space
-        
-    # _data_real_over_imag_idx_freq : 2D ndarray [n_pix, f_pix]
-    #     EXPERIMENTAL: Retrieve data (real priority) via indexing over frequency 
-    #     space
-
     freq : crikit.data.frequency.Frequency instance
         Frequency [wavelength, wavenumber] object (i.e., the independent \
         variable)

--- a/crikit/data/spectrum.py
+++ b/crikit/data/spectrum.py
@@ -19,16 +19,17 @@ class Spectrum:
     data : 1D ndarray [f_pix]
         Spectrum
 
-    _data_idx_freq : 1D ndarray [f_pix]
-        EXPERIMENTAL: Retrieve data via indexing over frequency space
+    # DISABLED CURRENTLY
+    # _data_idx_freq : 1D ndarray [f_pix]
+    #     EXPERIMENTAL: Retrieve data via indexing over frequency space
 
-    _data_imag_over_real_idx_freq : 1D ndarray [f_pix]
-        EXPERIMENTAL: Retrieve data (imag priority) via indexing over frequency
-        space
+    # _data_imag_over_real_idx_freq : 1D ndarray [f_pix]
+    #     EXPERIMENTAL: Retrieve data (imag priority) via indexing over frequency
+    #     space
 
-    _data_real_over_imag_idx_freq : 1D ndarray [f_pix]
-        EXPERIMENTAL: Retrieve data (real priority) via indexing over frequency
-        space
+    # _data_real_over_imag_idx_freq : 1D ndarray [f_pix]
+    #     EXPERIMENTAL: Retrieve data (real priority) via indexing over frequency
+    #     space
 
     freq : crikit.data.Frequency instance
         Frequency [wavelength, wavenumber] object (i.e., the independent \
@@ -98,11 +99,11 @@ class Spectrum:
         if meta is not None:
             self._meta = _copy.deepcopy(meta)
 
-        self._data_idx_freq = self._IndexDataByFreq(self, self._data)
-        self._data_imag_over_real_idx_freq = \
-            self._IndexDataByFreq(self, self.data_imag_over_real)
-        self._data_real_over_imag_idx_freq = \
-            self._IndexDataByFreq(self, self.data_real_over_imag)
+        # self._data_idx_freq = self._IndexDataByFreq(self, self._data)
+        # self._data_imag_over_real_idx_freq = \
+        #     self._IndexDataByFreq(self, self.data_imag_over_real)
+        # self._data_real_over_imag_idx_freq = \
+        #     self._IndexDataByFreq(self, self.data_real_over_imag)
 
     def __getitem__(self, idx):
         """
@@ -161,45 +162,50 @@ class Spectrum:
         else:
             return self._data
 
-    class _IndexDataByFreq:
-        """
-        Class that allows indexing of Spectrum.data by frequency instead of
-        just pixel number.
+    # class _IndexDataByFreq:
+    #     """
+    #     Class that allows indexing of Spectrum.data by frequency instead of
+    #     just pixel number.
 
-        Note: this is INCLUSIVE indexing by frequency
-        """
+    #     Note: this is INCLUSIVE indexing by frequency
+    #     """
 
-        def __init__(self, parent, to_return):
-            self._parent = parent
-            self._to_return = to_return
+    #     def __init__(self, parent, to_return):
+    #         self._parent = parent
+    #         self._to_return = to_return
 
-        def __getitem__(self, idx):
-            def _extract(self, idx):
-                if idx.step is None:
-                    starter = self._parent.freq.get_index_of_closest_freq(idx.start)
-                    ender = self._parent.freq.get_index_of_closest_freq(idx.stop)
-                    stepper = 1
-                    locs = _np.arange(starter, ender+1, stepper)
-                    return locs
-                else:
-                    starter = self._parent.freq.get_closest_freq(idx.start)
-                    ender = self._parent.freq.get_closest_freq(idx.stop)
-                    stepper = idx.step
-                    to_find = _np.arange(starter,ender,stepper)
-                    locs = _np.unique(self._parent.freq.get_index_of_closest_freq(to_find))
-                    # locs = _np.append(locs, locs[-1]+1)
-                    return locs
+    #     def __getitem__(self, idx):
+    #         def _extract(self, idx):
+    #             if idx.step is None:
+    #                 starter = self._parent.freq.get_index_of_closest_freq(idx.start)
+    #                 ender = self._parent.freq.get_index_of_closest_freq(idx.stop)
+    #                 stepper = 1
+    #                 locs = _np.arange(starter, ender+1, stepper)
+    #                 return locs
+    #             else:
+    #                 starter = self._parent.freq.get_closest_freq(idx.start)
+    #                 ender = self._parent.freq.get_closest_freq(idx.stop)
+    #                 stepper = idx.step
+    #                 to_find = _np.arange(starter,ender,stepper)
+    #                 locs = _np.unique(self._parent.freq.get_index_of_closest_freq(to_find))
+    #                 # locs = _np.append(locs, locs[-1]+1)
+    #                 return locs
 
-            if isinstance(idx, (int,float)):
-                loc = self._parent.freq.get_index_of_closest_freq(idx)
-                return self._to_return[...,loc]
-            elif isinstance(idx, slice):
-                locs = _extract(self, idx)
-                return self._to_return[...,locs]
-            elif isinstance(idx, (list,tuple)):
-                idx_space = idx[:-1]
-                locs = _extract(self, idx[-1])
-                return self._to_return[[*idx_space,locs]]
+    #         if isinstance(idx, (int,float)):
+    #             loc = self._parent.freq.get_index_of_closest_freq(idx)
+    #             return self._to_return[...,loc]
+    #         elif isinstance(idx, slice):
+    #             locs = _extract(self, idx)
+    #             return self._to_return[...,locs]
+    #         elif isinstance(idx, (list,tuple)):
+    #             print('Index: {}'.format(idx))
+    #             if all([isinstance(x,(float, int)) for x in idx]):
+    #                 loc = self._parent.freq.get_index_of_closest_freq(idx)
+    #                 return self._to_return[...,loc]
+    #             else:
+    #                 idx_space = idx[:-1]
+    #                 locs = _extract(self, idx[-1])
+    #                 return self._to_return[[*idx_space,locs]]
 
     @property
     def freq(self):
@@ -442,15 +448,15 @@ if __name__ == '__main__':  # pragma: no cover
     tmr -= _timeit.default_timer()
     print(-tmr)
 
-    tmr = _timeit.default_timer()
-    sp._data_idx_freq[500:600]
-    tmr -= _timeit.default_timer()
-    print(-tmr)
+    # tmr = _timeit.default_timer()
+    # sp._data_idx_freq[500:600]
+    # tmr -= _timeit.default_timer()
+    # print(-tmr)
 
-    tmr = _timeit.default_timer()
-    sp._data_imag_over_real_idx_freq[500:600]
-    tmr -= _timeit.default_timer()
-    print(-tmr)
+    # tmr = _timeit.default_timer()
+    # sp._data_imag_over_real_idx_freq[500:600]
+    # tmr -= _timeit.default_timer()
+    # print(-tmr)
 
     tmr = _timeit.default_timer()
     locs = _np.arange(sp.freq.get_index_of_closest_freq(500),

--- a/crikit/data/spectrum.py
+++ b/crikit/data/spectrum.py
@@ -19,18 +19,6 @@ class Spectrum:
     data : 1D ndarray [f_pix]
         Spectrum
 
-    # DISABLED CURRENTLY
-    # _data_idx_freq : 1D ndarray [f_pix]
-    #     EXPERIMENTAL: Retrieve data via indexing over frequency space
-
-    # _data_imag_over_real_idx_freq : 1D ndarray [f_pix]
-    #     EXPERIMENTAL: Retrieve data (imag priority) via indexing over frequency
-    #     space
-
-    # _data_real_over_imag_idx_freq : 1D ndarray [f_pix]
-    #     EXPERIMENTAL: Retrieve data (real priority) via indexing over frequency
-    #     space
-
     freq : crikit.data.Frequency instance
         Frequency [wavelength, wavenumber] object (i.e., the independent \
         variable)
@@ -99,27 +87,6 @@ class Spectrum:
         if meta is not None:
             self._meta = _copy.deepcopy(meta)
 
-        # self._data_idx_freq = self._IndexDataByFreq(self, self._data)
-        # self._data_imag_over_real_idx_freq = \
-        #     self._IndexDataByFreq(self, self.data_imag_over_real)
-        # self._data_real_over_imag_idx_freq = \
-        #     self._IndexDataByFreq(self, self.data_real_over_imag)
-
-    def __getitem__(self, idx):
-        """
-        Enable indexing and iterating through individual components of
-        self._data
-        """
-        if self._data is None:
-            return None
-        else:
-            if isinstance(idx, int):
-                return self._data[idx]
-            elif isinstance(idx, slice):
-                return self._data[idx]
-            else:
-                raise TypeError('Index must be of type int or slice')
-
     @property
     def data(self):
         return self._data
@@ -161,51 +128,6 @@ class Spectrum:
                 return _np.real(self._data)
         else:
             return self._data
-
-    # class _IndexDataByFreq:
-    #     """
-    #     Class that allows indexing of Spectrum.data by frequency instead of
-    #     just pixel number.
-
-    #     Note: this is INCLUSIVE indexing by frequency
-    #     """
-
-    #     def __init__(self, parent, to_return):
-    #         self._parent = parent
-    #         self._to_return = to_return
-
-    #     def __getitem__(self, idx):
-    #         def _extract(self, idx):
-    #             if idx.step is None:
-    #                 starter = self._parent.freq.get_index_of_closest_freq(idx.start)
-    #                 ender = self._parent.freq.get_index_of_closest_freq(idx.stop)
-    #                 stepper = 1
-    #                 locs = _np.arange(starter, ender+1, stepper)
-    #                 return locs
-    #             else:
-    #                 starter = self._parent.freq.get_closest_freq(idx.start)
-    #                 ender = self._parent.freq.get_closest_freq(idx.stop)
-    #                 stepper = idx.step
-    #                 to_find = _np.arange(starter,ender,stepper)
-    #                 locs = _np.unique(self._parent.freq.get_index_of_closest_freq(to_find))
-    #                 # locs = _np.append(locs, locs[-1]+1)
-    #                 return locs
-
-    #         if isinstance(idx, (int,float)):
-    #             loc = self._parent.freq.get_index_of_closest_freq(idx)
-    #             return self._to_return[...,loc]
-    #         elif isinstance(idx, slice):
-    #             locs = _extract(self, idx)
-    #             return self._to_return[...,locs]
-    #         elif isinstance(idx, (list,tuple)):
-    #             print('Index: {}'.format(idx))
-    #             if all([isinstance(x,(float, int)) for x in idx]):
-    #                 loc = self._parent.freq.get_index_of_closest_freq(idx)
-    #                 return self._to_return[...,loc]
-    #             else:
-    #                 idx_space = idx[:-1]
-    #                 locs = _extract(self, idx[-1])
-    #                 return self._to_return[[*idx_space,locs]]
 
     @property
     def freq(self):
@@ -442,21 +364,6 @@ if __name__ == '__main__':  # pragma: no cover
     sp.data[200:500]
     tmr -= _timeit.default_timer()
     print(-tmr)
-
-    tmr = _timeit.default_timer()
-    sp[200:500]
-    tmr -= _timeit.default_timer()
-    print(-tmr)
-
-    # tmr = _timeit.default_timer()
-    # sp._data_idx_freq[500:600]
-    # tmr -= _timeit.default_timer()
-    # print(-tmr)
-
-    # tmr = _timeit.default_timer()
-    # sp._data_imag_over_real_idx_freq[500:600]
-    # tmr -= _timeit.default_timer()
-    # print(-tmr)
 
     tmr = _timeit.default_timer()
     locs = _np.arange(sp.freq.get_index_of_closest_freq(500),

--- a/crikit/data/tests/~test_data_indexing.py
+++ b/crikit/data/tests/~test_data_indexing.py
@@ -27,6 +27,9 @@ def test_spectrum():
                                spectrum._data[0:11])
     np_testing.assert_allclose(spectrum._data_idx_freq[0.0:10.1],
                                spectrum._data[0:11])
+    np_testing.assert_equal(spectrum._data_idx_freq[10], spectrum._data[10])
+    np_testing.assert_allclose(spectrum._data_idx_freq[[10,11]], spectrum._data[[10,11]])
+    
     
 def test_spectra():
     N = 101
@@ -43,6 +46,8 @@ def test_spectra():
                                spectra._data[...,0:11])
     np_testing.assert_allclose(spectra._data_idx_freq[0.0:10.1],
                                spectra._data[...,0:11])
+    np_testing.assert_allclose(spectra._data_idx_freq[10], spectra._data[...,10])
+    np_testing.assert_allclose(spectra._data_idx_freq[[10,11]], spectra._data[...,[10,11]])
     
     # Slice the spatial dimension as well:
     np_testing.assert_allclose(spectra._data_idx_freq[:,0:10],
@@ -51,6 +56,9 @@ def test_spectra():
                                spectra._data[...,0:11])
     np_testing.assert_allclose(spectra._data_idx_freq[:,0.0:10.1],
                                spectra._data[...,0:11])
+    np_testing.assert_allclose(spectra._data_idx_freq[10,11], spectra._data[...,[10,11]])
+    np_testing.assert_allclose(spectra._data_idx_freq[:,10], spectra._data[...,10])
+    # np_testing.assert_allclose(spectra._data_idx_freq[:,[10,11]], spectrum._data[...,[10,11]])
 
 def test_hsi():
     N = 101
@@ -67,6 +75,8 @@ def test_hsi():
                                hsi._data[...,0:11])
     np_testing.assert_allclose(hsi._data_idx_freq[0.0:10.1],
                                hsi._data[...,0:11])
+    np_testing.assert_allclose(hsi._data_idx_freq[...,10], hsi._data[...,10])
+    np_testing.assert_allclose(hsi._data_idx_freq[...,[10,11]], hsi._data[...,[10,11]])
     
     # Slice the spatial dimension as well:
     np_testing.assert_allclose(hsi._data_idx_freq[:,:,0:10],
@@ -75,3 +85,8 @@ def test_hsi():
                                hsi._data[...,0:11])
     np_testing.assert_allclose(hsi._data_idx_freq[:,:,0.0:10.1],
                                hsi._data[...,0:11])
+    
+
+if __name__ == '__main__':
+    print('Here')
+    test_spectra()

--- a/crikit/measurement/peakfind.py
+++ b/crikit/measurement/peakfind.py
@@ -126,8 +126,12 @@ class PeakFinder:
         """
         deriv = _copy.deepcopy(signal)
         for count in range(order):
-            deriv = _convolve(deriv, PeakFinder.haar(wv_width), mode='same', 
-                            method=method)
+            try:
+                deriv = _convolve(deriv, PeakFinder.haar(wv_width), mode='same', 
+                                  method=method)
+            except:
+                print('peakfind.py | cwt_diff: Likely using an old version of SciPy (no convolve method parameter)')
+                deriv = _convolve(deriv, PeakFinder.haar(wv_width), mode='same')
         return deriv
 
     # @staticmethod

--- a/crikit/ui/widget_images.py
+++ b/crikit/ui/widget_images.py
@@ -488,7 +488,7 @@ class widgetSglColor(widgetBWImg):
                 self.data.colormap = color
 
             else:
-                self.data.colormap = _mpl.colors.to_rgb(_mpl.colors.cnames[color_str])
+                self.data.colormap = _mpl.colors.colorConverter.to_rgb(_mpl.colors.cnames[color_str])
 
         elif self.sender() == self.colormode.ui.comboBoxBGColor:
             bgcolor_str = self.colormode.ui.comboBoxBGColor.currentText()
@@ -499,7 +499,7 @@ class widgetSglColor(widgetBWImg):
                 self.data.bgcolor = bgcolor
 
             else:
-                self.data.bgcolor = _mpl.colors.to_rgb(_mpl.colors.cnames[bgcolor_str])
+                self.data.bgcolor = _mpl.colors.colorConverter.to_rgb(_mpl.colors.cnames[bgcolor_str])
         
         self.createImg(img = self.data.image, xunits = self.data.xunits,
                                 yunits = self.data.yunits,


### PR DESCRIPTION
CRIkit2 dev runs well on Py 3.6.

**Py3.4.4 results:**

```
C:\Python\crikit2 [dev ≡]> python -m crikit
No pyFFTW found. Using Scipy instead.
    You may want to install pyFFTW and FFTW for [potentially]
    significant performance enhancement
Traceback (most recent call last):
  File "C:\Users\chc\Documents\Python\WinPython-64bit-3.4.4.6Qt5\python-3.4.4.amd64\lib\runpy.py", line 170, in _run_module_as_main
    "__main__", mod_spec)
  File "C:\Users\chc\Documents\Python\WinPython-64bit-3.4.4.6Qt5\python-3.4.4.amd64\lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "C:\Users\chc\Documents\Python\crikit2\crikit\__main__.py", line 26, in <module>
    from crikit import CRIkitUI
  File "C:\Users\chc\Documents\Python\crikit2\crikit\CRIkitUI.py", line 58, in <module>
    from crikit.data.hsi import Hsi
  File "C:\Users\chc\Documents\Python\crikit2\crikit\data\hsi.py", line 13, in <module>
    from crikit.data.spectrum import Spectrum as _Spectrum
  File "C:\Users\chc\Documents\Python\crikit2\crikit\data\spectrum.py", line 202
    return self._to_return[[*idx_space,locs]]
                                           ^
SyntaxError: can use starred expression only as assignment target
```
**Py3.5.1 results:**
```
C:\Python\crikit2 [dev ≡]> python -m crikit
SW package not installed, using standard
Starting up crikit2...
Traceback (most recent call last):
  File "C:\Users\chc\Documents\Python\WinPython-64bit-3.5.2.1Qt5\python-3.5.2.amd64\lib\runpy.py", line 184, in _run_module_as_main
    "__main__", mod_spec)
  File "C:\Users\chc\Documents\Python\WinPython-64bit-3.5.2.1Qt5\python-3.5.2.amd64\lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "C:\Users\chc\Documents\Python\crikit2\crikit\__main__.py", line 48, in <module>
    _sys.exit(main())
  File "C:\Users\chc\Documents\Python\crikit2\crikit\__main__.py", line 40, in main
    win = CRIkitUI.CRIkitUI_process() ### EDIT ###
  File "C:\Users\chc\Documents\Python\crikit2\crikit\CRIkitUI.py", line 225, in __init__
    rgb_img.data.colormap = _mpl.colors.to_rgb(_mpl.colors.cnames[color_str])
AttributeError: module 'matplotlib.colors' has no attribute 'to_rgb'
```

Two incompatibilities
* list expansion mechanics in 3.4
    * Only used in experimental features of index-by-frequency
    * Solution: Disable this functionality (was buggy anyway)
* mpl.colors.to_rgb does not exists; rather is mpl.colors.colorConverter.to_rgb() in MPL < 2
    * Move to mpl.colors.colorConverter.to_rgb, which is available in all MPL versions


